### PR TITLE
Add support for E8 translation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub struct Lzxd {
     /// if the E8 Call Translation is not enabled for this stream.
     e8_translation_size: Option<u32>,
 
-    /// Temporary output buffer, used when E8 translation is enabled
+    /// Temporary output buffer, used when E8 translation is enabled.
     scratch_buffer: Vec<u8>,
 
     /// Current block.


### PR DESCRIPTION
This PR adds support for LZX E8 translation, as per [the documentation][1].

If E8 translation is enabled, we have to allocate and use a scratch buffer to postprocess the output data, since the window data must still contain the preprocessed data.


[1]: https://interoperability.blob.core.windows.net/files/MS-PATCH/%5BMS-PATCH%5D-100505.pdf