### PR TITLE
Add a fuzzer and fix a bunch of panics

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "lzxd-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.lzxd]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "lzxd"
+path = "fuzz_targets/lzxd.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/lzxd.rs
+++ b/fuzz/fuzz_targets/lzxd.rs
@@ -1,0 +1,24 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use lzxd::{Lzxd, WindowSize};
+
+fuzz_target!(|data: &[u8]| {
+    const WINDOW_SIZES: &[WindowSize] = &[
+        WindowSize::KB32,
+        WindowSize::KB64,
+        WindowSize::KB128,
+        WindowSize::KB256,
+        WindowSize::KB512,
+        WindowSize::MB1,
+        WindowSize::MB2,
+        WindowSize::MB4,
+        WindowSize::MB8,
+        WindowSize::MB16,
+        WindowSize::MB32,
+    ];
+
+    for ws in WINDOW_SIZES {
+        let mut lzxd = Lzxd::new(*ws);
+        let _ = lzxd.decompress_next(data);
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,7 @@ pub enum DecodeFailed {
     InvalidPretreeElement(u16),
 
     /// Invalid pretree run-length encoding.
-    // TODO: Better name?
-    InvalidPretreeRLE,
+    InvalidPretreeRle,
 
     /// When attempting to construct a decode tree, we encountered an invalid path length tree.
     InvalidPathLengths,
@@ -139,7 +138,7 @@ impl fmt::Display for DecodeFailed {
             InvalidBlock(kind) => write!(f, "block type {} is invalid", kind),
             InvalidBlockSize(size) => write!(f, "block size {} is invalid", size),
             InvalidPretreeElement(elem) => write!(f, "found invalid pretree element {}", elem),
-            InvalidPretreeRLE => write!(f, "found invalid pretree rle element"),
+            InvalidPretreeRle => write!(f, "found invalid pretree rle element"),
             InvalidPathLengths => write!(f, "encountered invalid path lengths"),
             WindowTooSmall => write!(f, "decode window was too small"),
             ChunkTooLong => write!(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -35,7 +35,7 @@ impl CanonicalTree {
     /// be used to better decode elements.
     // > an LZXD decoder uses only the path lengths of the Huffman tree to reconstruct the
     // > identical tree,
-    pub fn create_instance(&self) -> Tree {
+    pub fn create_instance(&self) -> Result<Tree, DecodeFailed> {
         // The ideas implemented by this method are heavily inspired from LeonBlade's xnbcli
         // on GitHub.
         //
@@ -43,7 +43,7 @@ impl CanonicalTree {
         // highest path length to determine how big our tree needs to be.
         let largest_length =
             NonZeroU8::new(*self.path_lengths.iter().max().expect("empty path lengths"))
-                .expect("all path lengths were 0");
+                .ok_or(DecodeFailed::InvalidPathLengths)?;
         let mut huffman_tree = vec![0; 1 << largest_length.get()];
 
         // > a zero path length indicates that the element has a zero frequency and is not
@@ -61,7 +61,9 @@ impl CanonicalTree {
                 // As soon as a code's path length matches with our bit index write the code as
                 // many times as the bit index itself represents.
                 if self.path_lengths[code] == bit {
-                    huffman_tree[pos..pos + amount]
+                    huffman_tree
+                        .get_mut(pos..pos + amount)
+                        .ok_or(DecodeFailed::InvalidPathLengths)?
                         .iter_mut()
                         .for_each(|x| *x = code as u16);
 
@@ -71,13 +73,15 @@ impl CanonicalTree {
         }
 
         // If we didn't fill the entire table, the path lengths were wrong.
-        assert_eq!(pos, huffman_tree.len());
+        if pos != huffman_tree.len() {
+            Err(DecodeFailed::InvalidPathLengths)?;
+        }
 
-        Tree {
+        Ok(Tree {
             path_lengths: self.path_lengths.clone(),
             largest_length,
             huffman_tree,
-        }
+        })
     }
 
     // Note: the tree already exists and is used to apply the deltas.
@@ -99,7 +103,7 @@ impl CanonicalTree {
                 path_lengths.push(bitstream.read_bits(4)? as u8)
             }
 
-            Tree::from_path_lengths(path_lengths)
+            Tree::from_path_lengths(path_lengths)?
         };
 
         // > Tree elements are output in sequential order starting with the first element.
@@ -121,14 +125,18 @@ impl CanonicalTree {
                 // > same path length.
                 17 => {
                     let zeros = bitstream.read_bits(4)?;
-                    self.path_lengths[i..i + zeros as usize + 4]
+                    self.path_lengths
+                        .get_mut(i..i + zeros as usize + 4)
+                        .ok_or(DecodeFailed::InvalidPretreeRLE)?
                         .iter_mut()
                         .for_each(|x| *x = 0);
                     i += zeros as usize + 4;
                 }
                 18 => {
                     let zeros = bitstream.read_bits(5)?;
-                    self.path_lengths[i..i + zeros as usize + 20]
+                    self.path_lengths
+                        .get_mut(i..i + zeros as usize + 20)
+                        .ok_or(DecodeFailed::InvalidPretreeRLE)?
                         .iter_mut()
                         .for_each(|x| *x = 0);
                     i += zeros as usize + 20;
@@ -137,9 +145,15 @@ impl CanonicalTree {
                     let same = bitstream.read_bits(1)?;
                     // "Decode new code" is used to parse the next code from the bitstream, which
                     // has a value range of [0, 16].
-                    let code = pretree.decode_element(bitstream)? as u8;
-                    let value = (17 + self.path_lengths[i] - code) % 17;
-                    self.path_lengths[i..i + same as usize + 4]
+                    let code = pretree.decode_element(bitstream)?;
+                    if code > 16 {
+                        return Err(DecodeFailed::InvalidPretreeElement(code))?;
+                    }
+
+                    let value = (17 + self.path_lengths[i] - code as u8) % 17;
+                    self.path_lengths
+                        .get_mut(i..i + same as usize + 4)
+                        .ok_or(DecodeFailed::InvalidPretreeRLE)?
                         .iter_mut()
                         .for_each(|x| *x = value);
                     i += same as usize + 4;
@@ -154,7 +168,7 @@ impl CanonicalTree {
 
 impl Tree {
     /// Create a new usable tree instance directly from known path lengths.
-    pub fn from_path_lengths(path_lengths: Vec<u8>) -> Self {
+    pub fn from_path_lengths(path_lengths: Vec<u8>) -> Result<Self, DecodeFailed> {
         CanonicalTree { path_lengths }.create_instance()
     }
 
@@ -185,7 +199,7 @@ mod tests {
     #[test]
     fn decode_simple_table() {
         // Based on some aligned offset tree
-        let tree = Tree::from_path_lengths(vec![6, 5, 1, 3, 4, 6, 2, 0]);
+        let tree = Tree::from_path_lengths(vec![6, 5, 1, 3, 4, 6, 2, 0]).unwrap();
         let value_count = vec![(2, 32), (6, 16), (3, 8), (4, 4), (1, 2), (0, 1), (5, 1)];
 
         let mut i = 0;
@@ -202,7 +216,8 @@ mod tests {
         // Based on the pretree of some length tree
         let tree = Tree::from_path_lengths(vec![
             1, 0, 0, 0, 0, 7, 3, 3, 4, 4, 5, 5, 5, 7, 8, 8, 0, 7, 0, 0,
-        ]);
+        ])
+        .unwrap();
         let value_count = vec![
             (0, 128),
             (6, 32),
@@ -230,7 +245,7 @@ mod tests {
 
     #[test]
     fn decode_elements() {
-        let tree = Tree::from_path_lengths(vec![6, 5, 1, 3, 4, 6, 2, 0]);
+        let tree = Tree::from_path_lengths(vec![6, 5, 1, 3, 4, 6, 2, 0]).unwrap();
 
         let buffer = [0x5b, 0xda, 0x3f, 0xf8];
         let mut bitstream = Bitstream::new(&buffer);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -127,7 +127,7 @@ impl CanonicalTree {
                     let zeros = bitstream.read_bits(4)?;
                     self.path_lengths
                         .get_mut(i..i + zeros as usize + 4)
-                        .ok_or(DecodeFailed::InvalidPretreeRLE)?
+                        .ok_or(DecodeFailed::InvalidPretreeRle)?
                         .iter_mut()
                         .for_each(|x| *x = 0);
                     i += zeros as usize + 4;
@@ -136,7 +136,7 @@ impl CanonicalTree {
                     let zeros = bitstream.read_bits(5)?;
                     self.path_lengths
                         .get_mut(i..i + zeros as usize + 20)
-                        .ok_or(DecodeFailed::InvalidPretreeRLE)?
+                        .ok_or(DecodeFailed::InvalidPretreeRle)?
                         .iter_mut()
                         .for_each(|x| *x = 0);
                     i += zeros as usize + 20;
@@ -153,7 +153,7 @@ impl CanonicalTree {
                     let value = (17 + self.path_lengths[i] - code as u8) % 17;
                     self.path_lengths
                         .get_mut(i..i + same as usize + 4)
-                        .ok_or(DecodeFailed::InvalidPretreeRLE)?
+                        .ok_or(DecodeFailed::InvalidPretreeRle)?
                         .iter_mut()
                         .for_each(|x| *x = value);
                     i += same as usize + 4;

--- a/src/window.rs
+++ b/src/window.rs
@@ -128,6 +128,10 @@ impl Window {
         bitstream: &mut Bitstream,
         len: usize,
     ) -> Result<(), DecodeFailed> {
+        if len > self.buffer.len() {
+            return Err(DecodeFailed::WindowTooSmall);
+        }
+
         if self.pos + len > self.buffer.len() {
             let shift = self.pos + len - self.buffer.len();
             self.pos -= shift;


### PR DESCRIPTION
This changeset adds a `cargo-fuzz` fuzzer and fixes a lot of panics that it found in this library.
For the panics, all I did was route them out as an error via the `DecodeFailed` enum.

Some of the new errors may not be the most descriptive since they were encountered deep within decompression code that I don't fully understand - so I'm definitely open to suggestions on better naming.

Note that this isn't an exhaustive PR - just merely my current progress on improving the robustness of this library.
The current issue I'm stuck on is in `BitStream` - `read_bits` is called with > 16 bits.