### PR TITLE
Allow inter-chunk uncompressed blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lzxd"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Lonami Exo <totufals@hotmail.com>"]
 license = "MIT OR Apache-2.0"
 description = """

--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -185,6 +185,11 @@ impl<'a> Bitstream<'a> {
         self.buffer = &self.buffer[real_len..];
         Ok(())
     }
+
+    pub fn remaining_bytes(&self) -> usize
+    {
+        self.buffer.len()
+    }
 }
 
 #[cfg(test)]

--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -186,8 +186,7 @@ impl<'a> Bitstream<'a> {
         Ok(())
     }
 
-    pub fn remaining_bytes(&self) -> usize
-    {
+    pub fn remaining_bytes(&self) -> usize {
         self.buffer.len()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,8 @@ impl Lzxd {
                     length
                 }
                 Decoded::Read(length) => {
+                    //Read up to end of chunk, allows intra-chunk blocks
+                    let length = usize::min(bitstream.remaining_bytes(), length);
                     // Will re-align if needed, just as decompressed reads mandate.
                     self.window.copy_from_bitstream(&mut bitstream, length)?;
                     length

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ impl Lzxd {
                     length
                 }
                 Decoded::Read(length) => {
-                    //Read up to end of chunk, allows intra-chunk blocks
+                    // Read up to end of chunk, to allow for larger blocks.
                     let length = usize::min(bitstream.remaining_bytes(), length);
                     // Will re-align if needed, just as decompressed reads mandate.
                     self.window.copy_from_bitstream(&mut bitstream, length)?;


### PR DESCRIPTION
This PR allows for a single uncompressed block to span multiple chunks, thus allowing for the decompression of blocks with size > 32KB via multiple calls to `decompress_next` when previously it failed with `DecodeFailed::UnexpectedEof`. I have only tested it with uncompressed blocks, although I'm not sure if this would apply to verbatim or aligned.
