### PR TITLE
Allow empty length trees

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -150,7 +150,11 @@ fn decode_element(
 
         let match_length = if length_header == 7 {
             // Length of the footer.
-            length_tree.unwrap().decode_element(bitstream)? + 7 + 2
+            length_tree
+                .ok_or(DecodeFailed::EmptyTree)?
+                .decode_element(bitstream)?
+                + 7
+                + 2
         } else {
             length_header + 2 // no length footer
                               // Decoding a match length (if a match length < 257).

--- a/src/block.rs
+++ b/src/block.rs
@@ -63,9 +63,10 @@ const BASE_POSITION: [u32; 290] = [
 struct DecodeInfo<'a> {
     aligned_offset_tree: Option<&'a Tree>,
     main_tree: &'a Tree,
-    length_tree: &'a Tree,
+    length_tree: Option<&'a Tree>,
 }
 
+#[derive(Debug)]
 pub enum Decoded {
     Single(u8),
     Match { offset: usize, length: usize },
@@ -75,12 +76,12 @@ pub enum Decoded {
 pub enum Kind {
     Verbatim {
         main_tree: Tree,
-        length_tree: Tree,
+        length_tree: Option<Tree>,
     },
     AlignedOffset {
         aligned_offset_tree: Tree,
         main_tree: Tree,
-        length_tree: Tree,
+        length_tree: Option<Tree>,
     },
     Uncompressed {
         r: [u32; 3],
@@ -149,7 +150,7 @@ fn decode_element(
 
         let match_length = if length_header == 7 {
             // Length of the footer.
-            length_tree.decode_element(bitstream)? + 7 + 2
+            length_tree.unwrap().decode_element(bitstream)? + 7 + 2
         } else {
             length_header + 2 // no length footer
                               // Decoding a match length (if a match length < 257).
@@ -268,7 +269,7 @@ impl Block {
 
                 Kind::Verbatim {
                     main_tree: state.main_tree.create_instance()?,
-                    length_tree: state.length_tree.create_instance()?,
+                    length_tree: state.length_tree.create_instance_allow_empty()?,
                 }
             }
             0b010 => {
@@ -291,7 +292,7 @@ impl Block {
                 Kind::AlignedOffset {
                     aligned_offset_tree,
                     main_tree: state.main_tree.create_instance()?,
-                    length_tree: state.length_tree.create_instance()?,
+                    length_tree: state.length_tree.create_instance_allow_empty()?,
                 }
             }
             0b011 => {
@@ -328,7 +329,7 @@ impl Block {
                 DecodeInfo {
                     aligned_offset_tree: None,
                     main_tree,
-                    length_tree,
+                    length_tree: length_tree.as_ref(),
                 },
             ),
             Kind::AlignedOffset {
@@ -341,7 +342,7 @@ impl Block {
                 DecodeInfo {
                     aligned_offset_tree: Some(aligned_offset_tree),
                     main_tree,
-                    length_tree,
+                    length_tree: length_tree.as_ref(),
                 },
             ),
             Kind::Uncompressed { r: new_r } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,9 @@ pub enum DecodeFailed {
     /// When attempting to construct a decode tree, we encountered an invalid path length tree.
     InvalidPathLengths,
 
+    /// A required decode tree was empty (all path lengths were 0).
+    EmptyTree,
+
     /// The given window size was too small.
     WindowTooSmall,
 
@@ -137,6 +140,7 @@ impl fmt::Display for DecodeFailed {
             InvalidPretreeElement(elem) => write!(f, "found invalid pretree element {}", elem),
             InvalidPretreeRle => write!(f, "found invalid pretree rle element"),
             InvalidPathLengths => write!(f, "encountered invalid path lengths"),
+            EmptyTree => write!(f, "encountered empty decode tree"),
             WindowTooSmall => write!(f, "decode window was too small"),
             ChunkTooLong => write!(
                 f,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -35,15 +35,18 @@ impl CanonicalTree {
     /// be used to better decode elements.
     // > an LZXD decoder uses only the path lengths of the Huffman tree to reconstruct the
     // > identical tree,
-    pub fn create_instance(&self) -> Result<Tree, DecodeFailed> {
+    pub fn create_instance_allow_empty(&self) -> Result<Option<Tree>, DecodeFailed> {
         // The ideas implemented by this method are heavily inspired from LeonBlade's xnbcli
         // on GitHub.
         //
         // The path lengths contains the bit indices or zero if its not present, so find the
         // highest path length to determine how big our tree needs to be.
         let largest_length =
-            NonZeroU8::new(*self.path_lengths.iter().max().expect("empty path lengths"))
-                .ok_or(DecodeFailed::InvalidPathLengths)?;
+            match NonZeroU8::new(*self.path_lengths.iter().max().expect("empty path lengths")) {
+                Some(x) => x,
+                // N.B: If all the path lengths are zero, then the tree is empty (which is allowed).
+                None => return Ok(None),
+            };
         let mut huffman_tree = vec![0; 1 << largest_length.get()];
 
         // > a zero path length indicates that the element has a zero frequency and is not
@@ -77,11 +80,16 @@ impl CanonicalTree {
             Err(DecodeFailed::InvalidPathLengths)?;
         }
 
-        Ok(Tree {
+        Ok(Some(Tree {
             path_lengths: self.path_lengths.clone(),
             largest_length,
             huffman_tree,
-        })
+        }))
+    }
+
+    pub fn create_instance(&self) -> Result<Tree, DecodeFailed> {
+        self.create_instance_allow_empty()?
+            .ok_or(DecodeFailed::InvalidPathLengths)
     }
 
     // Note: the tree already exists and is used to apply the deltas.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -29,7 +29,8 @@ impl CanonicalTree {
         }
     }
 
-    /// Create a new `Tree` instance from this cast that can be used to decode elements.
+    /// Create a new `Tree` instance from this cast that can be used to decode elements. If the
+    /// resulting tree is empty (all path lengths are 0), then `Ok(None)` is returned.
     ///
     /// This method transforms the canonical Huffman tree into a different structure that can
     /// be used to better decode elements.
@@ -87,9 +88,15 @@ impl CanonicalTree {
         }))
     }
 
+    /// Create a new `Tree` instance from this cast that can be used to decode elements.
+    ///
+    /// This method transforms the canonical Huffman tree into a different structure that can
+    /// be used to better decode elements.
+    // > an LZXD decoder uses only the path lengths of the Huffman tree to reconstruct the
+    // > identical tree,
     pub fn create_instance(&self) -> Result<Tree, DecodeFailed> {
         self.create_instance_allow_empty()?
-            .ok_or(DecodeFailed::InvalidPathLengths)
+            .ok_or(DecodeFailed::EmptyTree)
     }
 
     // Note: the tree already exists and is used to apply the deltas.


### PR DESCRIPTION
Length trees are allowed to be empty (zero maximum path length).

Reference (in addition to `BUILD_TABLE_MAYBE_EMPTY`):
https://github.com/kyz/libmspack/blob/305907723a4e7ab2018e58
40059ffb5e77db837/libmspack/mspack/lzxd.c#L555-L558