### PR TITLE
Cleanup E8 postprocessing logic; minor perf optimization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,13 +247,6 @@ impl Lzxd {
         chunk_offset: usize,
         idata: &'a mut [u8],
     ) -> Result<&'a [u8], DecodeFailed> {
-        // E8 fixups are disabled after 1GB of input data,
-        // or if the chunk size is too small.
-        if chunk_offset >= 0x4000_0000 || idata.len() <= 10 {
-            // NOTE: This should not be reached since our caller should be checking these conditions.
-            return Ok(idata);
-        }
-
         let mut processed = 0usize;
 
         // Find the next E8 match, or finish once there are no more E8 matches.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,14 +351,14 @@ impl Lzxd {
 
         let view = self.window.past_view(decoded_len)?;
         if let Some(postprocess) = self.postprocess.as_mut() {
-            let postprocess_buf = &mut postprocess.data_chunk[..decoded_len];
-            postprocess_buf.copy_from_slice(view);
-
             // E8 fixups are disabled after 1GB of input data,
             // or if the chunk size is too small.
             if chunk_offset >= 0x4000_0000 || decoded_len <= 10 {
                 Ok(view)
             } else {
+                let postprocess_buf = &mut postprocess.data_chunk[..decoded_len];
+                postprocess_buf.copy_from_slice(view);
+
                 // E8 fixups are enabled. Postprocess the output buffer.
                 Self::postprocess(
                     postprocess.e8_translation_size,


### PR DESCRIPTION
1) Prefer to encapsulate related optional fields into a single optional struct to avoid unwrapping
2) Check the postprocessing preconditions _before_ copying the past view into the postprocessing buffer.
3) Use `Bitstream::read_bits(32)` instead of stitching together two words.