### PR TITLE
fix: Removed check length of input

### DIFF
--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -169,7 +169,7 @@ impl<'a> Bitstream<'a> {
 
         // Add 1 to the len if it's odd
         self.buffer = &self.buffer[output.len()..];
-        if !self.buffer.is_empty() && output.len() % 2 != 0{
+        if !self.buffer.is_empty() && output.len() % 2 != 0 {
             self.buffer = &self.buffer[1..];
         }
         Ok(())


### PR DESCRIPTION
I try to fix: https://github.com/Lonami/lzxd/issues/21

Links to implementations which works:

1. https://github.com/GNOME/gcab/blob/master/libgcab/decomp.c
2. https://github.com/kyz/libmspack/blob/master/libmspack/mspack/lzxd.c
