### PR TITLE
fix: Re-align the bitstream

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -157,11 +157,7 @@ impl Window {
             let shift = len - self.pos;
             self.advance(shift);
 
-            let tmp = self.buffer[self.buffer.len() - shift..]
-                .into_iter()
-                .copied()
-                .collect::<Vec<_>>();
-
+            let tmp = self.buffer[self.buffer.len() - shift..].to_vec();
             self.buffer.copy_within(0..self.buffer.len() - shift, shift);
             self.buffer[..shift].copy_from_slice(&tmp);
         }


### PR DESCRIPTION
I fixed the issue: https://github.com/Lonami/lzxd/issues/21

I read source code [gcab](https://github.com/GNOME/gcab/blob/master/libgcab/decomp.c) and [libmspack](https://github.com/kyz/libmspack/blob/master/libmspack/mspack/lzxd.c) and find an interesting thin. After Uncompressed block if length is not Odd then re-align the bitstream.

Also I added:

- [x] `#[derive(Copy, Clone, Debug, Eq)]` to `DecompressError` and `DecodeFailed`
- [x]  Fixed some clippy warnings