### PR TITLE
fix: read u32 as DWORD

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -351,13 +351,13 @@ mod tests {
     #[test]
     fn check_past_view_new_max_size() {
         let mut window = WindowSize::KB32.create_buffer();
-        assert!(matches!(window.past_view(1 << 15), Ok(_)));
+        assert!(window.past_view(1 << 15).is_ok());
     }
 
     #[test]
     fn check_past_view_shifted_max_size() {
         let mut window = WindowSize::KB32.create_buffer();
         window.pos = 123;
-        assert!(matches!(window.past_view(1 << 15), Ok(_)));
+        assert!(window.past_view(1 << 15).is_ok());
     }
 }


### PR DESCRIPTION
@Lonami hello! This is fix for: https://github.com/Lonami/lzxd/issues/25

Could you make release with the patch?)